### PR TITLE
perf(import-x): resolver-next へ移行し no-cycle の外部走査を止める

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@typescript-eslint/utils": "8.59.3",
     "@vitest/eslint-plugin": "1.6.17",
     "eslint-config-flat-gitignore": "2.3.0",
-    "eslint-import-resolver-node": "0.4.0",
     "eslint-import-resolver-typescript": "4.4.4",
     "eslint-plugin-import-x": "4.16.2",
     "eslint-plugin-jest": "29.15.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,9 +41,6 @@ importers:
       eslint-config-flat-gitignore:
         specifier: 2.3.0
         version: 2.3.0(eslint@9.39.4(jiti@2.7.0))
-      eslint-import-resolver-node:
-        specifier: 0.4.0
-        version: 0.4.0
       eslint-import-resolver-typescript:
         specifier: 4.4.4
         version: 4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.4.0)(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
@@ -4847,6 +4844,7 @@ snapshots:
   debug@3.2.7:
     dependencies:
       ms: 2.1.3
+    optional: true
 
   debug@4.4.3:
     dependencies:
@@ -5103,6 +5101,7 @@ snapshots:
       resolve: 2.0.0-next.7
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   eslint-import-resolver-typescript@4.4.4(eslint-plugin-import-x@4.16.2(@typescript-eslint/utils@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.4.0)(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:

--- a/src/base/javascript.ts
+++ b/src/base/javascript.ts
@@ -2,7 +2,8 @@ import eslint from '@eslint/js'
 import eslintCommentsConfig from '@eslint-community/eslint-plugin-eslint-comments/configs'
 import stylisticPlugin from '@stylistic/eslint-plugin'
 import { defineConfig } from 'eslint/config'
-import { importX } from 'eslint-plugin-import-x'
+import { createTypeScriptImportResolver } from 'eslint-import-resolver-typescript'
+import { createNodeResolver, importX } from 'eslint-plugin-import-x'
 // @ts-expect-error 型定義ファイルがない
 import promisePlugin from 'eslint-plugin-promise'
 import unusedImportsPlugin from 'eslint-plugin-unused-imports'
@@ -164,20 +165,23 @@ export const javaScript = defineConfig(
       importX.flatConfigs.recommended,
     ],
     settings: {
-      'import-x/resolver': {
-        node: {
-          extensions: ['.js', '.cjs', '.mjs', '.jsx', '.ts', '.cts', '.mts', '.tsx', '.json'],
-        },
-        typescript: {
-          alwaysTryTypes: true,
-        },
-      },
+      // flat config 専用の新しい resolver API。旧 'import-x/resolver' は解決チェーンごとに
+      // resolver を作り直すためキャッシュが効かず、TypeScript の exports condition も評価できない
+      // (ESM import が CJS の型定義に解決され、tsc と ESLint で見えるモジュール形状がずれる)。
+      // resolver-next が設定されている場合、import-x は旧 'import-x/resolver' を一切参照しない。
+      'import-x/resolver-next': [
+        // alwaysTryTypes は v4 以降デフォルトで有効なため指定しない
+        createTypeScriptImportResolver(),
+        // tsconfig を持たないプロジェクト向けのフォールバック
+        createNodeResolver(),
+      ],
     },
     rules: {
       'import-x/no-import-module-exports': 'off',
       'import-x/no-extraneous-dependencies': 'off',
-      // 循環 import を禁止
-      'import-x/no-cycle': 'error',
+      // 循環 import を禁止する。node_modules 側の循環は利用者が修正できず、
+      // 依存グラフを外部モジュールまで展開するコストだけが大きいため対象外にする
+      'import-x/no-cycle': ['error', { ignoreExternal: true }],
       // default export を優先しない
       'import-x/prefer-default-export': 'off',
       // default export を禁止

--- a/src/base/typescript.ts
+++ b/src/base/typescript.ts
@@ -239,6 +239,13 @@ export const typeScript = defineConfig(
           ignorePackages: true,
         },
       ],
+      // 以下は tsc が同等以上の検査をする一方、import-x 側は対象モジュールを再パースして
+      // export 表を組み立てるため高価。importX.flatConfigs.typescript が同じ理由で
+      // 'import-x/named' を無効化しているのに倣い、TypeScript では残りも無効化する。
+      // namespace は TS2339、default は TS1192/TS2613、export は TS2323/TS2308 で検出される
+      'import-x/namespace': 'off',
+      'import-x/default': 'off',
+      'import-x/export': 'off',
     },
   },
   {


### PR DESCRIPTION
## 背景

nebula (frontend, 612 ファイル) で `TIMING=1` を取ったところ、lint 全体が 103 秒かかっていた。

| Rule | Time (ms) | Relative |
|:--|--:|--:|
| `import-x/no-cycle` | 45124.346 | 56.8% |
| `import-x/namespace` | 8373.752 | 10.5% |
| `react-hooks/static-components` | 5438.798 | 6.8% |
| `@typescript-eslint/no-deprecated` | 4453.392 | 5.6% |

## 原因

### 1. 旧 `import-x/resolver` は遅く、かつ解決結果が誤っていた

[README](https://github.com/un-ts/eslint-plugin-import-x#importxresolver-next) が flat config での推奨としている `resolver-next` に対し、本 config は legacy 形式を使っていた。

> Our v3 resolver interface shares a single `resolver` instance by default which is used all across resolving chains so it would benefit from caching and memoization out-of-the-box.

さらに legacy resolver は `exports` condition を評価できない。実際に `clsx` を追うと、

```
clsx.d.ts   (CJS)  →  export = clsx              ← 名前付き export なし
clsx.d.mts  (ESM)  →  export { clsx }; export default clsx
```

`moduleResolution: bundler` の tsconfig で tsc は `clsx.d.mts` を見るのに対し、ESLint は `clsx.d.ts` を見ていた。**ESLint と tsc がプロジェクト全体で別のモジュール形状を見ており、import 系ルールが黙って空振りしていた。** 性能だけでなく検出漏れの問題でもある。

なお `import-x` の precedence は排他で、`resolver-next` があれば legacy 側は参照されない。よって `importX.flatConfigs.typescript` が後から `'import-x/resolver': { typescript: true }` を上書きしても無害。

```js
// eslint-plugin-import-x lib/utils/resolve.js:155
if (settings['import-x/resolver-next']) { /* ... */ }
else { settings['import-x/resolver-legacy'] || settings['import-x/resolver'] || ... }
```

`alwaysTryTypes` は v4 以降デフォルト有効 (`options.alwaysTryTypes !== false`) のため明示指定を落とした。

### 2. `no-cycle` が node_modules まで依存グラフを展開していた

[ルールドキュメント](https://github.com/un-ts/eslint-plugin-import-x/blob/master/docs/rules/no-cycle.md) の通り `ignoreExternal` は既定 `false`。外部モジュール内の循環は利用者が修正できず、走査コストだけが大きい。

### 3. tsc と重複する import-x ルール

`namespace` / `default` / `export` は対象モジュールを再パースして export 表を組み立てるため高価。`importX.flatConfigs.typescript` が同じ理由で `import-x/named` を無効化しているのに倣い、TypeScript でのみ残りも無効化する。JS では有効なまま。

`import-x/cache: { lifetime: Infinity }` も検討したが、単独 92.4s・`resolver-next` 併用で改善なしのため見送った。README の通りこれは `eslint_d` 等の常駐プロセス向け。

## 効果

nebula での実測 (各 1 回計測):

| 構成 | 全体 wall | `no-cycle` | `namespace` |
|:--|--:|--:|--:|
| 変更前 | 103.0s | 45.1s | 8.4s |
| `resolver-next` のみ | 47.8s | 11.0s | 2.5s |
| + `ignoreExternal` | 39.6s | 1.3s | 5.0s |
| **本 PR (+ TS 重複ルール off)** | **34.1s** | **1.8s** | – |

**103.0s → 34.1s (-67%)**

## 検証

- `pnpm build` (tsc) — 通過
- `pnpm lint` — exit 0

内部循環の検出が維持されることを一時ファイルで確認した。

```
src/__perfcheck/a.ts  2:1  error  Dependency cycle detected  import-x/no-cycle
src/__perfcheck/c.ts  1:1  error  Dependency cycle detected  import-x/no-cycle
```

`namespace` を無効化しても tsc が同等の検査をすることも確認した。

```
src/__perfcheck/a.ts(4,34): error TS2339: Property 'missingMember' does not exist on
  type 'typeof import(".../src/__perfcheck/b")'.
```

## 既知の影響

resolver が正しく解決するようになった結果、これまで空振りしていた警告が顕在化する。いずれもエラーではないため CI は通るが、`--max-warnings=0` を設定している利用者は対応が必要になる。

- 本リポジトリ: 25 件 (`import-x/extensions` × 16、`import-x/no-named-as-default-member` × 9)
- nebula: 13 件 (`clsx` × 8、`DOMPurify` × 1、`typescript` × 4)

うち `import-x/extensions` の 16 件は、tsc emit するプロジェクトがソースに `.js` 指定子を書く構成と `import-x/extensions: 'always'` が両立しないことによる。本 PR のスコープ外とし、別途扱う。

## 動物界における比擬

アリは巣から餌場まで、通った道にフェロモンを残す。後続の個体はその痕跡をたどるだけでよく、経路を一から探索し直す必要がない。旧 resolver はこのフェロモンを残さない働きアリで、同じ道を何度も一から嗅ぎ回っていた。`resolver-next` が単一インスタンスを共有するのは、巣全体でフェロモン地図を共有するのに等しい。

しかもこの働きアリは、匂いの種類を取り違えていた。同じ巣穴に見えて中身が違う二つの入口 (`clsx.d.ts` と `clsx.d.mts`) のうち、いつも間違ったほうへ入っていた。速くなったことより、正しい巣穴に入るようになったことのほうが重要である。

`ignoreExternal` は縄張りの線引きにあたる。ミーアキャットの歩哨は地平線まで見張るが、隣の谷で何が起きているかまでは追わない。自分たちが逃げ込める巣穴の範囲こそが警戒に値する範囲だからだ。node_modules の奥で起きている循環は、こちらが掘り直せる穴ではない。
