### PR TITLE
feat(react)!: eslint-plugin-jsx-a11y を fork の jsx-a11y-x へ移行

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "eslint-import-resolver-typescript": "4.4.4",
     "eslint-plugin-import-x": "4.16.2",
     "eslint-plugin-jest": "29.15.2",
-    "eslint-plugin-jsx-a11y": "6.10.2",
+    "eslint-plugin-jsx-a11y-x": "0.2.0",
     "eslint-plugin-n": "18.0.1",
     "eslint-plugin-package-json": "0.91.2",
     "eslint-plugin-promise": "7.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,9 +53,9 @@ importers:
       eslint-plugin-jest:
         specifier: 29.15.2
         version: 29.15.2(@typescript-eslint/eslint-plugin@8.59.3(@typescript-eslint/parser@8.59.3(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
-      eslint-plugin-jsx-a11y:
-        specifier: 6.10.2
-        version: 6.10.2(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-jsx-a11y-x:
+        specifier: 0.2.0
+        version: 0.2.0(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-n:
         specifier: 18.0.1
         version: 18.0.1(eslint@9.39.4(jiti@2.7.0))(ts-declaration-location@1.0.7(typescript@6.0.3))(typescript@6.0.3)
@@ -1510,9 +1510,6 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  ast-types-flow@0.0.8:
-    resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
-
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
@@ -1525,8 +1522,8 @@ packages:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
 
-  axe-core@4.11.4:
-    resolution: {integrity: sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==}
+  axe-core@4.12.1:
+    resolution: {integrity: sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==}
     engines: {node: '>=4'}
 
   axobject-query@4.1.0:
@@ -1768,9 +1765,6 @@ packages:
   electron-to-chromium@1.5.357:
     resolution: {integrity: sha512-NHlTIQDK8fmVwHwuIzmXYEJ1Ewq3D9wDNc0cWXxDGysP6Pb21giwGNkxiTifyKy/4SoPuN5l6GLP1W9Sv7zB2g==}
 
-  emoji-regex@9.2.2:
-    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
-
   enhanced-resolve@5.21.3:
     resolution: {integrity: sha512-QyL119InA+XXEkNLNTPCXPugSvOfhwv0JOlGNzvxs0hZaiHLNvXSpudUWsOlsXGWJh8G6ckCScEkVHfX3kw/2Q==}
     engines: {node: '>=10.13.0'}
@@ -1908,11 +1902,11 @@ packages:
       typescript:
         optional: true
 
-  eslint-plugin-jsx-a11y@6.10.2:
-    resolution: {integrity: sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==}
-    engines: {node: '>=4.0'}
+  eslint-plugin-jsx-a11y-x@0.2.0:
+    resolution: {integrity: sha512-O/VpKt2G38VCMlBgGCH8eJGWXM05z892zGKeuPfPATMPLDZOWeVtKS8SBt98ElaeFRKcJEv2bELub+Llo3m9zw==}
+    engines: {node: ^20.9.0 || >=21.1.0}
     peerDependencies:
-      eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9
+      eslint: ^9.0.0 || ^10.0.0
 
   eslint-plugin-n@18.0.1:
     resolution: {integrity: sha512-q3ARhk+eZRc7myR0KHx+R3/GJeOHF+Ir6PK95Pu2tEX8Sl/4BIpmmVLva2kPrjC2gCmn6WHlHm+3yeo6Rxhycw==}
@@ -2575,6 +2569,10 @@ packages:
     resolution: {integrity: sha512-75EA7EWZExL/j+MDKQrRbdzcRI2HOkRlmUw8fZJc1ioqFEOvBsq7Rt+A6yCxOt9w/TYNpkt52gC6nm/g5tFIng==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
+  jsx-ast-utils-x@0.1.0:
+    resolution: {integrity: sha512-eQQBjBnsVtGacsG9uJNB8qOr3yA8rga4wAaGG1qRcBzSIvfhERLrWxMAM1hp5fcS6Abo8M4+bUBTekYR0qTPQw==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
@@ -3048,10 +3046,6 @@ packages:
 
   string-ts@2.3.1:
     resolution: {integrity: sha512-xSJq+BS52SaFFAVxuStmx6n5aYZU571uYUnUrPXkPFCfdHyZMMlbP2v2Wx5sNBnAVzq/2+0+mcBLBa3Xa5ubYw==}
-
-  string.prototype.includes@2.0.1:
-    resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
-    engines: {node: '>= 0.4'}
 
   string.prototype.matchall@4.0.12:
     resolution: {integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==}
@@ -4690,8 +4684,6 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  ast-types-flow@0.0.8: {}
-
   ast-types@0.16.1:
     dependencies:
       tslib: 2.8.1
@@ -4702,7 +4694,7 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.1.0
 
-  axe-core@4.11.4: {}
+  axe-core@4.12.1: {}
 
   axobject-query@4.1.0: {}
 
@@ -4925,8 +4917,6 @@ snapshots:
       gopd: 1.2.0
 
   electron-to-chromium@1.5.357: {}
-
-  emoji-regex@9.2.2: {}
 
   enhanced-resolve@5.21.3:
     dependencies:
@@ -5155,24 +5145,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-jsx-a11y@6.10.2(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-jsx-a11y-x@0.2.0(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       aria-query: 5.3.2
-      array-includes: 3.1.9
-      array.prototype.flatmap: 1.3.3
-      ast-types-flow: 0.0.8
-      axe-core: 4.11.4
+      axe-core: 4.12.1
       axobject-query: 4.1.0
       damerau-levenshtein: 1.0.8
-      emoji-regex: 9.2.2
       eslint: 9.39.4(jiti@2.7.0)
-      hasown: 2.0.3
-      jsx-ast-utils: 3.3.5
+      jsx-ast-utils-x: 0.1.0
       language-tags: 1.0.9
-      minimatch: 3.1.5
-      object.fromentries: 2.0.8
-      safe-regex-test: 1.1.0
-      string.prototype.includes: 2.0.1
+      minimatch: 10.2.5
 
   eslint-plugin-n@18.0.1(eslint@9.39.4(jiti@2.7.0))(ts-declaration-location@1.0.7(typescript@6.0.3))(typescript@6.0.3):
     dependencies:
@@ -5988,6 +5970,8 @@ snapshots:
       eslint-visitor-keys: 5.0.1
       semver: 7.8.0
 
+  jsx-ast-utils-x@0.1.0: {}
+
   jsx-ast-utils@3.3.5:
     dependencies:
       array-includes: 3.1.9
@@ -6548,12 +6532,6 @@ snapshots:
   string-env-interpolation@1.0.1: {}
 
   string-ts@2.3.1: {}
-
-  string.prototype.includes@2.0.1:
-    dependencies:
-      call-bind: 1.0.9
-      define-properties: 1.2.1
-      es-abstract: 1.24.2
 
   string.prototype.matchall@4.0.12:
     dependencies:

--- a/src/frameworks/react.ts
+++ b/src/frameworks/react.ts
@@ -1,7 +1,6 @@
 import eslintReact from '@eslint-react/eslint-plugin'
 import { defineConfig } from 'eslint/config'
-// @ts-expect-error 型定義ファイルがない
-import jsxA11y from 'eslint-plugin-jsx-a11y'
+import jsxA11yX from 'eslint-plugin-jsx-a11y-x'
 import reactPlugin from 'eslint-plugin-react'
 import reactHooksPlugin from 'eslint-plugin-react-hooks'
 import globals from 'globals'
@@ -124,12 +123,18 @@ export const react = defineConfig(
       ],
     },
   },
+  // eslint-plugin-jsx-a11y-x（本家 eslint-plugin-jsx-a11y のフォーク）
+  // 本家は 2024-10 の 6.10.2 を最後にリリースが止まっており、ESLint v10 で削除された
+  // context.getFilename() を内部で使っているため v10 ではロード時にクラッシュする。
+  // https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/1075
+  // フォーク側は当該 API を排除済みで recommended のルール構成は本家と一致する。
+  // 本家が v10 対応をリリースしたら戻せるよう、ルール名の変更以外は同じ設定を保つ。
   {
-    name: 'eslint-plugin-jsx-a11y',
+    name: 'eslint-plugin-jsx-a11y-x',
     files: ['**/*.{jsx,tsx}'],
-    extends: [jsxA11y.flatConfigs.recommended],
+    extends: [jsxA11yX.configs.recommended],
     rules: {
-      'jsx-a11y/alt-text': [
+      'jsx-a11y-x/alt-text': [
         'warn',
         {
           elements: ['img', 'object', 'area'],


### PR DESCRIPTION
## 概要

`eslint-plugin-jsx-a11y` を、es-tooling による fork の [`eslint-plugin-jsx-a11y-x`](https://github.com/es-tooling/eslint-plugin-jsx-a11y-x) へ差し替える。

## 背景

本家 `eslint-plugin-jsx-a11y` は **2024-10-26 の 6.10.2 を最後にリリースが止まっている**。ESLint v10 で削除された `context.getFilename()` を内部で使っているため、v10 ではルールのロード時に `TypeError` でクラッシュする。

ESLint v10 対応の Issue は open のまま進捗がなく、#1074（ESLint v10 移行）のブロッカーになっている。

- 上流 Issue: [jsx-eslint/eslint-plugin-jsx-a11y#1075 — [Feature] Support for ESLint v10](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/1075)（2026-02-09 起票、未解決）

fork 側は当該 API を排除済みで、peer に `eslint ^9.0.0 || ^10.0.0` を宣言している。

## 変更内容

| パッケージ | 旧 | 新 |
|---|---|---|
| `eslint-plugin-jsx-a11y` | `6.10.2` | 削除 |
| `eslint-plugin-jsx-a11y-x` | — | `0.2.0` |

- `jsxA11y.flatConfigs.recommended` → `jsxA11yX.configs.recommended`（fork は `configs` 直下に置く）
- `jsx-a11y/alt-text` → `jsx-a11y-x/alt-text`
- 型定義が同梱されたため `// @ts-expect-error 型定義ファイルがない` を削除
- 移行の背景（本家のリリース停止・上流 Issue）をソースコメントとして記録

fork は本家の依存 15 個を 7 個まで削っているため、lockfile が 62 行減っている。

## ルール互換性

`recommended` プリセットのルール構成は本家と**完全一致**していることを実測で確認した。

```
x count 36 / orig count 39
only in orig: accessible-emoji, label-has-for, no-onchange   ← いずれも本家で deprecated
only in x   : （なし）
recommended プリセットの差分: なし
```

## ⚠️ 破壊的変更

**ルールの名前空間が `jsx-a11y/` から `jsx-a11y-x/` に変わる。**

利用側で以下の書き換えが必要になる。

```diff
- // eslint-disable-next-line jsx-a11y/alt-text
+ // eslint-disable-next-line jsx-a11y-x/alt-text
```

```diff
  rules: {
-   'jsx-a11y/no-autofocus': 'off',
+   'jsx-a11y-x/no-autofocus': 'off',
  }
```

## 将来的な巻き戻し

本家が ESLint v10 対応をリリースした場合に戻せるよう、ルール名の変更以外は同じ設定を保っている。その旨をソースコメントにも残した。

## 検証

`pnpm build`（`tsc`）: エラーなし

`pnpm lint`: 指摘なし

React プリセット経由で `.tsx` を lint し、ルールが発火することを確認した。

```
  4:7   warning  img elements must have an alt prop...            jsx-a11y-x/alt-text
  5:7   error    Anchor used as a button...                       jsx-a11y-x/anchor-is-valid
  5:7   error    Visible, non-interactive elements with click...  jsx-a11y-x/click-events-have-key-events
  5:7   error    Avoid non-native interactive elements...         jsx-a11y-x/no-static-element-interactions
  5:10  warning  JSX props should not use arrow functions         react/jsx-no-bind
✖ 5 problems (3 errors, 2 warnings)
```

`alt-text` のみ `warning` として出ているのは、fork の `recommended`（`error`）の上に本リポジトリの `'warn'` 上書きが正しく効いていることを示す。

## 未検証事項

本 PR 単体では ESLint v9 環境での検証にとどまる。ESLint v10 との組み合わせは `eslint-plugin-react` が依然クラッシュするため通しで検証できていない（#1074 の残課題）。fork が ESLint 10.8.0 で単体動作することは別途確認済み。

## 関連

- #1074 — ESLint v10 移行。本 PR で a11y 側のブロッカーは解消するが、`eslint-plugin-react` 側（[jsx-eslint/eslint-plugin-react#3977](https://github.com/jsx-eslint/eslint-plugin-react/issues/3977)）は未解決のまま残る。

## 動物界における比擬

ヤドカリは自分で殻を作らない。巻貝の遺した殻を借りて腹部を守り、体が育てば手狭になった殻を捨てて次の殻へ移る。移動の瞬間、柔らかい腹部は無防備に晒される。

`eslint-plugin-jsx-a11y` は長く快適な殻だった。しかし本家の更新が止まり、ESLint v10 という成長した体には殻が割れて使えなくなった。`eslint-plugin-jsx-a11y-x` は隣に転がっていた同型の殻である。内部の巻き（ルール構成）はほぼ同じで、外殻の刻印（名前空間）だけが `jsx-a11y-x/` と異なる。

ヤドカリの世界には「空き家連鎖（vacancy chain）」という現象がある。大きな殻が空くと、一匹が移り、その空いた殻に次が移り、と行列状に住み替えが連鎖していく。ESLint v10 という新しい殻が空いたことで、エコシステム全体がいま同じ連鎖の途上にある。本 PR はその行列の一歩ぶんにあたる。

そして本家が v10 対応の殻を新調したなら、また戻ればよい。ヤドカリにとって殻は所有物ではなく、その時いちばん体に合う借り物にすぎない。
